### PR TITLE
feat(clinic-user): add many-to-many relationship

### DIFF
--- a/project/DoctorON_api/app/Http/Controllers/UserController.php
+++ b/project/DoctorON_api/app/Http/Controllers/UserController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\User\StoreUserRequest;
+use App\Http\Requests\User\UpdateUserRequest;
+use App\Services\UserService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Exception;
+
+class UserController extends Controller
+{
+    protected $userService;
+
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    public function index(): JsonResponse
+    {
+        try {
+            $users = $this->userService->getAllUsers();
+            return response()->json($users);
+        } catch (Exception $e) {
+            Log::error('Erro ao buscar todos os usuários: ' . $e->getMessage());
+            return response()->json(['message' => 'Ocorreu um erro ao processar sua solicitação.'], 500);
+        }
+    }
+
+    public function store(StoreUserRequest $request): JsonResponse
+    {
+        try {
+            $validatedData = $request->validated();
+            $user = $this->userService->createUser($validatedData);
+            return response()->json($user, 201);
+        } catch (Exception $e) {
+            Log::error('Erro ao criar usuário: ' . $e->getMessage());
+            return response()->json(['message' => 'Ocorreu um erro ao criar o usuário.'], 500);
+        }
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        try {
+            $user = $this->userService->getUserById($id);
+            if (!$user) {
+                return response()->json(['message' => 'User not found'], 404);
+            }
+            return response()->json($user);
+        } catch (Exception $e) {
+            Log::error("Erro ao buscar usuário com ID {$id}: " . $e->getMessage());
+            return response()->json(['message' => 'Ocorreu um erro ao buscar o usuário.'], 500);
+        }
+    }
+
+    public function update(UpdateUserRequest $request, int $id): JsonResponse
+    {
+        try {
+            $validatedData = $request->validated();
+
+            if (array_key_exists('password', $validatedData) && empty($validatedData['password'])) {
+                unset($validatedData['password']);
+            }
+
+            $user = $this->userService->updateUser($id, $validatedData);
+
+            if (!$user) {
+                return response()->json(['message' => 'User not found or could not be updated'], 404);
+            }
+
+            return response()->json($user);
+        } catch (Exception $e) {
+            Log::error("Erro ao atualizar usuário com ID {$id}: " . $e->getMessage());
+            return response()->json(['message' => 'Ocorreu um erro ao atualizar o usuário.'], 500);
+        }
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        try {
+            $deleted = $this->userService->deleteUser($id);
+            if (!$deleted) {
+                return response()->json(['message' => 'User not found or could not be deleted'], 404);
+            }
+            return response()->json(null, 204);
+        } catch (Exception $e) {
+            Log::error("Erro ao deletar usuário com ID {$id}: " . $e->getMessage());
+            return response()->json(['message' => 'Ocorreu um erro ao deletar o usuário.'], 500);
+        }
+    }
+}

--- a/project/DoctorON_api/app/Http/Requests/User/StoreUserRequest.php
+++ b/project/DoctorON_api/app/Http/Requests/User/StoreUserRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password; // Para regras de senha mais robustas (opcional)
+
+class StoreUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users,email',
+            'password' => [
+                'required',
+                'string',
+                'confirmed', // Requer um campo 'password_confirmation'
+                Password::min(8) // Exemplo de regra de senha mais robusta
+                // ->mixedCase()
+                // ->numbers()
+                // ->symbols()
+                // ->uncompromised(), // Verifica se a senha apareceu em vazamentos de dados (requer API key)
+            ],
+            // Adicione outras regras de validação conforme necessário
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'O campo nome é obrigatório.',
+            'email.required' => 'O campo e-mail é obrigatório.',
+            'email.email' => 'Por favor, insira um endereço de e-mail válido.',
+            'email.unique' => 'Este e-mail já está em uso.',
+            'password.required' => 'O campo senha é obrigatório.',
+            'password.confirmed' => 'A confirmação da senha não corresponde.',
+            'password.min' => 'A senha deve ter pelo menos :min caracteres.',
+        ];
+    }
+}

--- a/project/DoctorON_api/app/Http/Requests/User/UpdateUserRequest.php
+++ b/project/DoctorON_api/app/Http/Requests/User/UpdateUserRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+
+class UpdateUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $userId = $this->route('user');
+
+        return [
+            'name' => 'sometimes|required|string|max:255',
+            'email' => [
+                'sometimes',
+                'required',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->ignore($userId),
+            ],
+            'password' => [
+                'sometimes',
+                'nullable',
+                'string',
+                'confirmed',
+                Password::min(8)
+            ],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'O campo nome é obrigatório quando fornecido.',
+            'email.required' => 'O campo e-mail é obrigatório quando fornecido.',
+            'email.email' => 'Por favor, insira um endereço de e-mail válido.',
+            'email.unique' => 'Este e-mail já está em uso por outro usuário.',
+            'password.confirmed' => 'A confirmação da senha não corresponde.',
+            'password.min' => 'A senha deve ter pelo menos :min caracteres quando fornecida.',
+        ];
+    }
+}

--- a/project/DoctorON_api/app/Repositories/UserRepository.php
+++ b/project/DoctorON_api/app/Repositories/UserRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+
+namespace App\Repositories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Hash;
+
+class UserRepository
+{
+    protected $model;
+
+    public function __construct(User $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Cria um novo usuário.
+     *
+     * @param array $data
+     * @return User
+     */
+    public function create(array $data): User
+    {
+        return $this->model->create($data);
+    }
+
+    /**
+     * Encontra um usuário pelo ID.
+     * Lança ModelNotFoundException se não encontrar.
+     *
+     * @param int $id
+     * @return User|null
+     */
+    public function find(int $id): ?User
+    {
+        return $this->model->findOrFail($id);
+    }
+
+    /**
+     * Retorna todos os usuários.
+     * Pode adicionar paginação aqui se necessário.
+     *
+     * @return Collection
+     */
+    public function all(): Collection
+    {
+        return $this->model->all();
+    }
+
+    /**
+     * Atualiza um usuário existente.
+     *
+     * @param int $id
+     * @param array $data
+     * @return User|null
+     */
+    public function update(int $id, array $data): ?User
+    {
+        $user = $this->find($id);
+        if ($user) {
+            $user->update($data);
+            return $user;
+        }
+        return null;
+    }
+
+    /**
+     * Deleta um usuário.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function delete(int $id): bool
+    {
+        $user = $this->find($id);
+        if ($user) {
+            return $user->delete();
+        }
+        return false;
+    }
+}

--- a/project/DoctorON_api/app/Services/UserService.php
+++ b/project/DoctorON_api/app/Services/UserService.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace App\Services;
+
+use App\Repositories\UserRepository;
+use App\Models\User;
+
+// Necessário para type hinting de retorno
+use Illuminate\Database\Eloquent\Collection;
+
+// Necessário para type hinting de retorno
+use Illuminate\Support\Facades\Log;
+
+// Opcional, para logging
+
+class UserService
+{
+    protected $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
+    /**
+     * Cria um novo usuário.
+     *
+     * @param array $data Dados do usuário.
+     * @return User
+     */
+    public function createUser(array $data): User
+    {
+        // Aqui você pode adicionar lógica de negócios antes de criar o usuário,
+        // como validações complexas, disparar eventos, etc.
+        // Ex: if (isset($data['password'])) {
+        // $data['password'] = bcrypt($data['password']); // Se não estiver usando o cast 'hashed' no model
+        // }
+        return $this->userRepository->create($data);
+    }
+
+    /**
+     * Obtém um usuário pelo ID.
+     *
+     * @param int $id
+     * @return User|null
+     */
+    public function getUserById(int $id): ?User
+    {
+        return $this->userRepository->find($id);
+    }
+
+    /**
+     * Obtém todos os usuários.
+     *
+     * @return Collection
+     */
+    public function getAllUsers(): Collection
+    {
+        return $this->userRepository->all();
+    }
+
+    /**
+     * Atualiza um usuário existente.
+     *
+     * @param int $id
+     * @param array $data
+     * @return User|null
+     */
+    public function updateUser(int $id, array $data): ?User
+    {
+         if (isset($data['password']) && !empty($data['password'])) {
+         $data['password'] = bcrypt($data['password']);
+         } else {
+         unset($data['password']);
+         }
+        return $this->userRepository->update($id, $data);
+    }
+
+    /**
+     * Deleta um usuário.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public function deleteUser(int $id): bool
+    {
+        return $this->userRepository->delete($id);
+    }
+}

--- a/project/DoctorON_api/config/auth.php
+++ b/project/DoctorON_api/config/auth.php
@@ -66,7 +66,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', \app\Models\User::class),
+            'model' => env('AUTH_MODEL', App\Models\User::class),
         ],
 
         // 'users' => [

--- a/project/DoctorON_api/routes/api/authenticated.php
+++ b/project/DoctorON_api/routes/api/authenticated.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\MedicController;
 use App\Http\Controllers\PatientController;
 use App\Http\Controllers\ClinicController;
+use App\Http\Controllers\UserController;
 use App\Http\Middleware\Middleware;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -36,4 +37,10 @@ Route::middleware([Middleware::class])->group(function () {
     Route::post('/clinicas', [ClinicController::class, 'register']);
     Route::put('/clinic/{clinic_id}', [ClinicController::class, 'updateClinic']);
 
+    Route::get('/user/{id}', [UserController::class, 'show']);
+    Route::put('/user/{id}', [UserController::class, 'update']); // Ou Route::patch para atualizações parciais
+    Route::delete('/user/{id}', [UserController::class, 'destroy']);
+
+
 });
+

--- a/project/DoctorON_api/routes/api/unauthenticated.php
+++ b/project/DoctorON_api/routes/api/unauthenticated.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\CityController;
 use App\Http\Controllers\MedicController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -31,3 +32,5 @@ Route::get('/cidades', [CityController::class, 'index']);
 Route::get('/cidades/{id_cidade}/medicos', [CityController::class, 'getMedicosByCidade']);
 
 Route::get('/medicos', [MedicController::class, 'index']);
+
+Route::post('/user/register', [UserController::class, 'store']);


### PR DESCRIPTION
This commit establishes a many-to-many relationship between users and clinics, enabling a user to belong to multiple clinics with a specific role.

- Creates the migration for the `users_clinics` pivot table, using a custom name instead of the Laravel convention.
- Adds `role` and `created_by` columns to the pivot table to manage user permissions and track association creation. The table also includes timestamps and soft deletes.
- Defines the `belongsToMany` relationships in both the `Clinic` and `User` models to articulate the new association.
- Updates the `ClinicRepository` to handle the logic for attaching users to clinics.